### PR TITLE
Add an overlay with GPIO line names for RZ

### DIFF
--- a/arch/arm64/boot/dts/amlogic/overlays/meson-g12a-gpio-line-names.dts
+++ b/arch/arm64/boot/dts/amlogic/overlays/meson-g12a-gpio-line-names.dts
@@ -1,0 +1,20 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&gpio_ao>;
+
+		__overlay__ {
+			gpio-line-names = "GPIOAO_0", "GPIOAO_1", "GPIOAO_2", "GPIOAO_3", "GPIOAO_4", "GPIOAO_5", "GPIOAO_6", "GPIOAO_7", "GPIOAO_8", "GPIOAO_9", "GPIOAO_10", "GPIOAO_11", "GPIOE_0", "GPIOE_1", "GPIOE_2";
+		};
+	};
+
+	fragment@1 {
+		target = <&gpio>;
+
+		__overlay__ {
+			gpio-line-names = "GPIOZ_0", "GPIOZ_1", "GPIOZ_2", "GPIOZ_3", "GPIOZ_4", "GPIOZ_5", "GPIOZ_6", "GPIOZ_7", "GPIOZ_8", "GPIOZ_9", "GPIOZ_10", "GPIOZ_11", "GPIOZ_12", "GPIOZ_13", "GPIOZ_14", "GPIOZ_15", "GPIOH_0", "GPIOH_1", "GPIOH_2", "GPIOH_3", "GPIOH_4", "GPIOH_5", "GPIOH_6", "GPIOH_7", "GPIOH_8", "BOOT_0", "BOOT_1", "BOOT_2", "BOOT_3", "BOOT_4", "BOOT_5", "BOOT_6", "BOOT_7", "BOOT_8", "BOOT_9", "BOOT_10", "BOOT_11", "BOOT_12", "BOOT_13", "BOOT_14", "BOOT_15", "GPIOC_0", "GPIOC_1", "GPIOC_2", "GPIOC_3", "GPIOC_4", "GPIOC_5", "GPIOC_6", "GPIOC_7", "GPIOA_0", "GPIOA_1", "GPIOA_2", "GPIOA_3", "GPIOA_4", "GPIOA_5", "GPIOA_6", "GPIOA_7", "GPIOA_8", "GPIOA_9", "GPIOA_10", "GPIOA_11", "GPIOA_12", "GPIOA_13", "GPIOA_14", "GPIOA_15", "GPIOX_0", "GPIOX_1", "GPIOX_2", "GPIOX_3", "GPIOX_4", "GPIOX_5", "GPIOX_6", "GPIOX_7", "GPIOX_8", "GPIOX_9", "GPIOX_10", "GPIOX_11", "GPIOX_12", "GPIOX_13", "GPIOX_14", "GPIOX_15", "GPIOX_16", "GPIOX_17", "GPIOX_18", "GPIOX_19";
+		};
+	};
+};


### PR DESCRIPTION
As Theophile [suggested](https://forum.radxa.com/t/gpiod-support-on-radxa-zero/12039/2), this overlay proposes to map names on the lines of the Radxa Zero, so that they appear in eg `gpioinfo` from the `libgpiod` package. I did my best to match precisely the pinout, but I'm lacking hardware competences and equipment to be sure.

In my opinion, this kind of information should land in the main .dts file, because : 
  - it doesn't bring any functionality in, so it is harmless
  - it's a big payload of meaning for a very small amount of information

... but I'm fine with it being an overlay for the time being.

Could you review this MR ?