### PR TITLE
Create rk3399-sp2-sc16is752.dts

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -17,6 +17,7 @@ dtb-$(CONFIG_CLK_RK3399) += \
 	rk3399-spi2-spidev.dtbo \
 	rk3399-spi2-enc28j60.dtbo \
 	rk3399-spi5-enc28j60.dtbo \
+	rk3399-spi2-sc16is752.dtbo \
 	rk3399-uart0.dtbo \
 	rk3399-uart2.dtbo \
 	rk3399-uart4.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-sp2-sc16is752.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-sp2-sc16is752.dts
@@ -1,7 +1,18 @@
 /dts-v1/;
 /plugin/;
 
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
 /{
+	metadata {
+		title = "Enable SC16is752 on SPI2";
+		compatible = "rockchip,rk3399";
+		category = "misc";
+		description = "Enable SC16is752 SPI on SPI2.\nINT=38";
+	};
+	
 	compatible = "rockchip,rk3399";
 
 	fragment@0 {
@@ -19,7 +30,19 @@
 		target = <&spi2>;
 
 		__overlay__ {
-			status = "okay";On 2>;
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi2_clk &spi2_cs0 &spi2_rx &spi2_tx>;
+			cs-gpios = <&gpio2 RK_PB4 GPIO_ACTIVE_LOW>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sc16is752: sc16is752@0 {
+				compatible = "nxp,sc16is752";
+				reg = <0>;
+				clocks = <&sc16is752_clk>;
+				interrupt-parent = <&gpio4>;
+				interrupts = <RK_PA6 IRQ_TYPE_EDGE_FALLING>;
 				spi-max-frequency = <4000000>;
 				#gpio-controller;
 				#gpio-cells = <2>;

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-sp2-sc16is752.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-sp2-sc16is752.dts
@@ -7,13 +7,11 @@
 
 /{
 	metadata {
-		title = "Enable SC16is752 on SPI2";
+		title = "Enable SC16IS752 on SPI2";
 		compatible = "rockchip,rk3399";
 		category = "misc";
-		description = "Enable SC16is752 SPI on SPI2.\nINT=38";
+		description = "Enable SC16IS752 SPI on SPI2.\nINT=38";
 	};
-	
-	compatible = "rockchip,rk3399";
 
 	fragment@0 {
 		target-path = "/";
@@ -33,17 +31,19 @@
 			status = "okay";
 			pinctrl-names = "default";
 			pinctrl-0 = <&spi2_clk &spi2_cs0 &spi2_rx &spi2_tx>;
-			cs-gpios = <&gpio2 RK_PB4 GPIO_ACTIVE_LOW>;
+
 			#address-cells = <1>;
 			#size-cells = <0>;
 
 			sc16is752: sc16is752@0 {
 				compatible = "nxp,sc16is752";
 				reg = <0>;
-				clocks = <&sc16is752_clk>;
+				spi-max-frequency = <4000000>;
+				
 				interrupt-parent = <&gpio4>;
 				interrupts = <RK_PA6 IRQ_TYPE_EDGE_FALLING>;
-				spi-max-frequency = <4000000>;
+
+				clocks = <&sc16is752_clk>;
 				#gpio-controller;
 				#gpio-cells = <2>;
 			};

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-sp2-sc16is752.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-sp2-sc16is752.dts
@@ -1,0 +1,41 @@
+/dts-v1/;
+/plugin/;
+
+/{
+	compatible = "rockchip,rk3399";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			sc16is752_clk: sc16is752_spi2_0_clk {
+				compatible = "fixed-clock";
+				clock-frequency = <1475600>;
+				#clock-cells = <0>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spi2>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi2_clk &spi2_cs0 &spi2_rx &spi2_tx>;
+			cs-gpios = <&gpio4 7 1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			sc16is752: sc16is752@0 {
+				compatible = "nxp,sc16is752";
+				reg = <0>;
+				clocks = <&sc16is752_clk>;
+				interrupt-parent = <&gpio4>;
+				interrupts = <7 2>;
+				spi-max-frequency = <4000000>;
+				#gpio-controller;
+				#gpio-cells = <2>;
+			};
+		};
+	};
+};

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-sp2-sc16is752.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-sp2-sc16is752.dts
@@ -19,19 +19,7 @@
 		target = <&spi2>;
 
 		__overlay__ {
-			status = "okay";
-			pinctrl-names = "default";
-			pinctrl-0 = <&spi2_clk &spi2_cs0 &spi2_rx &spi2_tx>;
-			cs-gpios = <&gpio4 7 1>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			sc16is752: sc16is752@0 {
-				compatible = "nxp,sc16is752";
-				reg = <0>;
-				clocks = <&sc16is752_clk>;
-				interrupt-parent = <&gpio4>;
-				interrupts = <7 2>;
+			status = "okay";On 2>;
 				spi-max-frequency = <4000000>;
 				#gpio-controller;
 				#gpio-cells = <2>;


### PR DESCRIPTION
Overlay for https://www.waveshare.com/wiki/2-CH_RS232_HAT using SP2 Someone else might find this useful and update with some param overrides.

Clock defines were annoying hard to get right, due to how linux kernel was probing.
Thankfully found a github issue about it on raspberry pi repos
https://github.com/raspberrypi/linux/issues/3765

SPI2 pins & IRQ = GPIO4_A7
Barely tested using Rock Pi 4b plus. Linux Kernel 5.15-80-rockchip64, but dev/ttySC0  + ttySC1 were created