### PR TITLE
Otg

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rk3588-dwc3-host.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3588-dwc3-host.dts
@@ -1,0 +1,21 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Set OTG port to Peripheral mode";
+		compatible = "rockchip,rk3588";
+		category = "misc";
+		exclusive = "usbdrd_dwc3-dr_mode";
+		description = "Set OTG port to Peripheral mode.\nUse this when you want to connect to another computer.";
+	};
+
+	fragment@0 {
+		target = <&usbdrd_dwc3_0>;
+
+		__overlay__ {
+			status = "okay";
+			dr_mode = "host";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3588-dwc3-host.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3588-dwc3-host.dts
@@ -7,7 +7,7 @@
 		compatible = "radxa,rock-5b";
 		category = "misc";
 		exclusive = "usbdrd_dwc3-dr_mode";
-		description = "Set OTG port to Peripheral mode.\nUse this when you want to connect to another computer.";
+		description = "Set OTG port to Host mode.\nUse this when you want to connect USB devices.";
 	};
 
 	fragment@0 {

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3588-dwc3-host.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3588-dwc3-host.dts
@@ -4,7 +4,7 @@
 / {
 	metadata {
 		title = "Set OTG port to Peripheral mode";
-		compatible = "rockchip,rk3588";
+		compatible = "radxa,rock-5b";
 		category = "misc";
 		exclusive = "usbdrd_dwc3-dr_mode";
 		description = "Set OTG port to Peripheral mode.\nUse this when you want to connect to another computer.";

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3588-dwc3-host.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3588-dwc3-host.dts
@@ -3,7 +3,7 @@
 
 / {
 	metadata {
-		title = "Set OTG port to Peripheral mode";
+		title = "Set OTG port to Host mode";
 		compatible = "rockchip,rk3588";
 		category = "misc";
 		exclusive = "usbdrd_dwc3-dr_mode";

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3588-dwc3-host.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3588-dwc3-host.dts
@@ -4,7 +4,7 @@
 / {
 	metadata {
 		title = "Set OTG port to Peripheral mode";
-		compatible = "radxa,rock-5b";
+		compatible = "rockchip,rk3588";
 		category = "misc";
 		exclusive = "usbdrd_dwc3-dr_mode";
 		description = "Set OTG port to Host mode.\nUse this when you want to connect USB devices.";

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3588-dwc3-peripheral.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3588-dwc3-peripheral.dts
@@ -1,0 +1,21 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Set OTG port to Peripheral mode";
+		compatible = "rockchip,rk3588";
+		category = "misc";
+		exclusive = "usbdrd_dwc3-dr_mode";
+		description = "Set OTG port to Peripheral mode.\nUse this when you want to connect to another computer.";
+	};
+
+	fragment@0 {
+		target = <&usbdrd_dwc3_0>;
+
+		__overlay__ {
+			status = "okay";
+			dr_mode = "peripheral";
+		};
+	};
+};


### PR DESCRIPTION
 rk3588-dwc3-peripheral.dts 这个用通用的"rockchip,rk3588" 这个compatible没问题.
 rk3588-dwc3-host.dts， compatilble 用具体的 "radxa,rock-5a" 这种还是用 "rockchip,rk3588"这种呢？我看rk3568-dwc-host 用的是"rockchip,rk3568"这种，但是5a的dts 里面dr_mode  默认是 host , 对5a 来说， compatible 用"rockchip,rk3588"，这个overlay 有点多余,