### PR TITLE
add radxa rock 5a and radxa rock 5b uart2-m0 support

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rk3588-uart2-m0.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3588-uart2-m0.dts
@@ -4,7 +4,7 @@
 / {
 	metadata {
 		title = "Enable UART2-M0";
-		compatible = "unknown";
+		compatible = "radxa,rock-5a", "radxa,rock-5b";
 		category = "misc";
 		exclusive = "GPIO0_B5", "GPIO0_B6";
 		description = "Enable UART2-M0.\nOn Radxa ROCK 5A this is TX pin 8 and RX pin 10.\nOn Radxa ROCK 5B this is TX pin 8 and this is RX pin 10.";


### PR DESCRIPTION
使用uart2-m0, 需要手动删除 /boot/extlinux/extlinux.conf 里面的串口控制台相关的内容
"115200n8 console=ttyS2,1500000n8 console=ttyFIQ0,", description, 需要怎么写呢?