### PR TITLE
delete uart8-m1 for the reason uart8-m0 conflicts with bt

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rk3568-uart8-m1.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3568-uart8-m1.dts
@@ -4,7 +4,7 @@
 / {
 	metadata {
 		title = "Enable UART8-M1";
-		compatible = "radxa,rock-3b";
+		compatible = "unknown";
 		category = "misc";
 		description = "Enable UART8-M1.\nOn Radxa ROCK 3B this is TX pin 29 and RX pin 31.";
 	};


### PR DESCRIPTION
uart8-m1 无法使用，原因: uart8 的m0 通道被 bluetooth 占用， wiki 上已经删除了uart8-m1 的功能