### PR TITLE
delete mcp2515 on radxa rock 5b for the test failed

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rk3588-spi1-m1-cs1-mcp2515-8mhz.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3588-spi1-m1-cs1-mcp2515-8mhz.dts
@@ -8,7 +8,7 @@
 / {
 	metadata {
 		title = "Enable MCP2515 with 8MHz external clock on SPI1-M1 over CS1";
-		compatible = "radxa,rock-5b";
+		compatible = "unknown";
 		category = "misc";
 		description = "Provide support for Microchip MCP2515 SPI CAN controller.\nAssumes 8MHz external clock.\nUses Pin 19 (GPIOI1_B2) for INT.";
 	};


### PR DESCRIPTION
我打开overlay 、接好线上电后，没有看到 can0 ,然后dmesg |grep spi 也有一堆报错，这个模块要不先删除，后面有时间再统一调一下吧?