### PR TITLE
Fixed bug where fiq could not be disabled for uart2-m2

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rk3588-uart2-m2.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3588-uart2-m2.dts
@@ -11,6 +11,15 @@
 	};
 
 	fragment@0 {
+		target = <&fiq_debugger>;
+
+		__overlay__ {
+			status = "okay";
+			rockchip,serial-id = <0xffffffff>;
+		};
+	};
+
+	fragment1 {
 		target = <&uart2>;
 
 		__overlay__ {


### PR DESCRIPTION
可以禁用fiq，但是还有原uart2-m0串口打印， 但是不影响它作为普通通信串口使用