### PR TITLE
fix: replace `disable` with `disabled`

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rock-5a-spi-flash.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rock-5a-spi-flash.dts
@@ -51,7 +51,7 @@
 		target = <&sdhci>;
 
 		__overlay__ {
-			status = "disable";
+			status = "disabled";
 		};
 	};
 };


### PR DESCRIPTION
fixed typo on rock-5a-spi-flash overlay