### PR TITLE
Add ROCK 5A ROCK 5B can overlays

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -162,6 +162,8 @@ dtb-$(CONFIG_CPU_RK3568) += \
 	rock-3b-radxa-10p1inch-display.dtbo
 
 dtb-$(CONFIG_CLK_RK3588) += \
+	rk3588-can1-m0.dtbo \
+	rk3588-can1-m1.dtbo \
 	rk3588-dwc3-host.dtbo \
 	rk3588-dwc3-peripheral.dtbo \
 	rk3588-fiq-debugger-uart2m2.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3588-can1-m0.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3588-can1-m0.dts
@@ -1,0 +1,34 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/rk3588-cru.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+#include <dt-bindings/soc/rockchip,boot-mode.h>
+#include <dt-bindings/phy/phy.h>
+#include <dt-bindings/power/rk3588-power.h>
+#include <dt-bindings/soc/rockchip-system-status.h>
+
+/ {
+	metadata {
+		title = "Enable CAN1-M0";
+		compatible = "radxa,rock-5b";
+		category = "misc";
+		exclusive = "GPIO3_B5", "GPIO3_B6";
+		description = "Enable CAN1-M0.\nOn Radxa ROCK 5B this is RX pin 12 & TX pin 35.";
+	};
+
+    fragment@0 {
+        target = <&can1>;
+
+        __overlay__ {
+			status = "okay";
+			compatible = "rockchip,can-2.0";
+			assigned-clocks = <&cru CLK_CAN0>;
+			assigned-clock-rates = <200000000>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&can1m0_pins>;
+		};
+    };
+};

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3588-can1-m1.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3588-can1-m1.dts
@@ -1,0 +1,34 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/rk3588-cru.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+#include <dt-bindings/soc/rockchip,boot-mode.h>
+#include <dt-bindings/phy/phy.h>
+#include <dt-bindings/power/rk3588-power.h>
+#include <dt-bindings/soc/rockchip-system-status.h>
+
+/ {
+	metadata {
+		title = "Enable CAN1-M1";
+		compatible = "radxa,rock-5a", "radxa,rock-5b";
+		category = "misc";
+		exclusive = "GPIO4_B2", "GPIO4_B3";
+		description = "Enable CAN1-M0.\nOn Radxa ROCK 5A this is RX pin 13 & TX pin 11.\nOn Radxa ROCK 5B this is RX pin 5 & TX pin 3.\n";
+	};
+
+    fragment@0 {
+        target = <&can1>;
+
+        __overlay__ {
+			compatible = "rockchip,can-2.0";
+			status = "okay";
+			assigned-clocks = <&cru CLK_CAN1>;
+			assigned-clock-rates = <200000000>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&can1m1_pins>;
+        };
+    };
+};


### PR DESCRIPTION
测试通过，但是需要使用的话，需要打开内核 can 的驱动