### PR TITLE
delete Radxa Zero2 compatible support for mcp2515

### DIFF
--- a/arch/arm64/boot/dts/amlogic/overlays/meson-g12-spi-b-mcp2515-8mhz.dts
+++ b/arch/arm64/boot/dts/amlogic/overlays/meson-g12-spi-b-mcp2515-8mhz.dts
@@ -8,7 +8,7 @@
 / {
 	metadata {
 		title = "Enable MCP2515 with 8MHz external clock on SPI_B and GPIOX_8";
-		compatible = "radxa,zero", "radxa,zero2";
+		compatible = "radxa,zero";
 		category = "misc";
 		exclusive = "spicc1", "GPIOH_4", "GPIOH_5", "GPIOH_6", "GPIOH_7", "GPIOX_8";
 		description = "Provide support for Microchip MCP2515 SPI CAN controller.\nAssumes 8MHz external clock.\nUses Pin 18 (GPIOX_8) for INT.";


### PR DESCRIPTION
Zero2 没有 GPIOX_8 引脚