### PR TITLE
cm3s io: camera v2: Modify the control method of pwdn_gpio

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3s-io-csi0-rpi-camera-v2.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3s-io-csi0-rpi-camera-v2.dts
@@ -24,6 +24,16 @@
 				clock-output-names = "ext_cam_clk_imx219_0";
 				#clock-cells = <0>;
 			};
+
+			camera_pwdn_gpio: camera-pwdn-gpio {
+				status = "okay";
+				compatible = "regulator-fixed";
+				regulator-name = "camera_pwdn_gpio";
+				regulator-always-on;
+				regulator-boot-on;
+				enable-active-high;
+				gpio = <&gpio3 RK_PD7 GPIO_ACTIVE_HIGH>;
+			};
 		};
 	};
 
@@ -43,7 +53,6 @@
 				reg = <0x10>;
 				clocks = <&ext_cam_clk_imx219_0>;
 				clock-names = "ext_cam_clk_imx219_0";
-				pwdn-gpios = <&gpio3 RK_PD7 GPIO_ACTIVE_HIGH>;
 				rockchip,camera-module-index = <1>;
 				rockchip,camera-module-facing = "front";
 				rockchip,camera-module-name = "rpi-camera-v2";

--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3s-io-csi1-rpi-camera-v2.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3s-io-csi1-rpi-camera-v2.dts
@@ -24,6 +24,16 @@
 				clock-output-names = "ext_cam_clk_imx219_1";
 				#clock-cells = <0>;
 			};
+
+			camera_pwdn_gpio: camera-pwdn-gpio {
+				status = "okay";
+				compatible = "regulator-fixed";
+				regulator-name = "camera_pwdn_gpio";
+				regulator-always-on;
+				regulator-boot-on;
+				enable-active-high;
+				gpio = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
+			};
 		};
 	};
 
@@ -41,7 +51,6 @@
 				reg = <0x10>;
 				clocks = <&ext_cam_clk_imx219_1>;
 				clock-names = "ext_cam_clk_imx219_1";
-				pwdn-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
 				rockchip,camera-module-index = <1>;
 				rockchip,camera-module-facing = "front";
 				rockchip,camera-module-name = "rpi-camera-v2";


### PR DESCRIPTION
The original control method is invalid in the 5.10 kernel driver, and the regulator is used to realize it.