### PR TITLE
open Radxa Zero2 pwm_b overlays

### DIFF
--- a/arch/arm64/boot/dts/amlogic/overlays/meson-g12-pwm-b-h.dts
+++ b/arch/arm64/boot/dts/amlogic/overlays/meson-g12-pwm-b-h.dts
@@ -4,7 +4,7 @@
 / {
 	metadata {
 		title = "Enable PWM-B on GPIOH_7";
-		compatible = "unknown";
+		compatible = "radxa,zero2";
 		category = "misc";
 		exclusive = "pwm_ab", "GPIOH_7";
 		description = "Enable PWM-B on GPIOH_7.";

--- a/arch/arm64/boot/dts/amlogic/overlays/meson-g12-pwm-b-z.dts
+++ b/arch/arm64/boot/dts/amlogic/overlays/meson-g12-pwm-b-z.dts
@@ -4,7 +4,7 @@
 / {
 	metadata {
 		title = "Enable PWM-B on GPIOZ_0";
-		compatible = "unknown";
+		compatible = "radxa,zero2";
 		category = "misc";
 		exclusive = "pwm_ab", "GPIOZ_0";
 		description = "Enable PWM-B on GPIOZ_0.";


### PR DESCRIPTION
CONFIG_PWM_MESON=m, 这个驱动没开

其他几个还不知道什么原因