### PR TITLE
cm3 io: disable pwm0, set hym8563 overlay to unknown,fix pcie overlay.

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3-io-i2c0-hym8563.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3-io-i2c0-hym8563.dts
@@ -4,7 +4,7 @@
 / {
 	metadata {
 		title = "Enable HYM8563 RTC on I2C0";
-		compatible = "radxa,cm3-io";
+		compatible = "unknown";
 		category = "misc";
 		description = "Enable HYM8563 RTC on I2C0.";
 	};

--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3-io-pcie2x1.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3-io-pcie2x1.dts
@@ -1,15 +1,37 @@
 /dts-v1/;
 /plugin/;
 
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+
 / {
 	metadata {
 		title = "Enable PCIe";
 		compatible = "radxa,cm3-io";
 		category = "misc";
+		exclusive = "pcie2x1";
 		description = "Enable PCIe.\nWhen PCIe is enabled, SATA2 cannot be enabled on the same port.";
 	};
 
 	fragment@0 {
+		target-path = "/";
+
+		__overlay__ {
+			vcc-ch482d2-regulator {
+				compatible = "regulator-fixed";
+				enable-active-low;
+				gpio = <&gpio3 RK_PC6 GPIO_ACTIVE_LOW>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&ch482d_en2>;
+				regulator-name = "vcc_ch482d2";
+				regulator-always-on;
+				regulator-boot-on;
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@1 {
 		target = <&pcie2x1>;
 
 		__overlay__ {
@@ -17,6 +39,25 @@
 			reset-gpios = <&gpio1 0x0a 0x00>;
 			vpcie3v3-supply = <&vcc3v3_sys>;
 			pinctrl-0 = <&pcie20m2_pins>;
+		};
+	};
+
+	fragment@2 {
+		target = <&sata2>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@3 {
+		target = <&pinctrl>;
+		__overlay__ {
+			ch482d {
+				ch482d_en2: ch482d-en2 {
+					rockchip,pins = <3 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
+				};
+			};
 		};
 	};
 };

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3568-pwm0-m0.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3568-pwm0-m0.dts
@@ -4,7 +4,7 @@
 / {
 	metadata {
 		title = "Enable PWM0-M0";
-		compatible = "radxa,cm3-io", "radxa,cm3-rpi-cm4-io";
+		compatible = "radxa,cm3-rpi-cm4-io";
 		category = "misc";
 		description = "Enable PWM0-M0.\nOn Radxa CM3 IO this is pin 13.\nOn Radxa CM3 RPI CM4 this is on pin 13.";
 	};

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3568-pwm0-m1.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3568-pwm0-m1.dts
@@ -4,7 +4,7 @@
 / {
 	metadata {
 		title = "Enable PWM0-M1";
-		compatible = "radxa,cm3-io", "radxa,cm3-rpi-cm4-io";
+		compatible = "radxa,cm3-rpi-cm4-io";
 		category = "misc";
 		description = "Enable PWM0-M1.\nOn Radxa CM3 IO this is pin 11.\nOn Radxa CM3 RPI CM4 this is on pin 11.";
 	};


### PR DESCRIPTION
pwm0 is used by the fan， hym8563 rtc device integrated on the CM3IO base board.