### PR TITLE
add carMp3 pwm ir remotectl for rock4

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -32,6 +32,7 @@ dtb-$(CONFIG_CLK_RK3399) += \
 	rk3399-opp-2200.dtbo \
 	rk3399-opp-2400.dtbo \
 	rk3399-pcie0-gen2.dtbo \
+	rk3399-pwm-ir-remotectl.dtbo \
 	rk3399-pwm0.dtbo \
 	rk3399-pwm1.dtbo \
 	rk3399-radxa-25w-poe.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -32,8 +32,8 @@ dtb-$(CONFIG_CLK_RK3399) += \
 	rk3399-opp-2200.dtbo \
 	rk3399-opp-2400.dtbo \
 	rk3399-pcie0-gen2.dtbo \
-	rk3399-pwm-ir-remotectl.dtbo \
 	rk3399-pwm0.dtbo \
+	rk3399-pwm1-ir-rx.dtbo \
 	rk3399-pwm1.dtbo \
 	rk3399-radxa-25w-poe.dtbo \
 	rk3399-rga-400.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-pwm-ir-remotectl.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-pwm-ir-remotectl.dts
@@ -1,0 +1,54 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+    metadata {
+		title = "Enable IR receiver on PWM1";
+		compatible = "rockchip,rk3399";
+		category = "misc";
+		exclusive = "GPIO4_C6";
+		description = "Enable IR receiver on PWM1.";
+	};
+
+	fragment@0 {
+		target = <&pwm1>;
+
+		__overlay__ {
+			compatible = "rockchip,remotectl-pwm";
+			remote_pwm_id = <1>;
+			handle_cpu_id = <1>;
+			remote_support_psci = <1>;
+			status = "okay";
+			pinctrl-0 = <&pwm1_pin>;
+			pinctrl-names = "default";
+			interrupts = <GIC_SPI 61 IRQ_TYPE_LEVEL_HIGH 0>;
+
+			ir_key1 {
+				rockchip,usercode = <0xff00>;
+				rockchip,key_table =
+					<0xba	KEY_CHANNELDOWN>,
+					<0xb9	KEY_CHANNEL>,
+					<0xb8	KEY_CHANNELUP>,
+					<0xbb	KEY_PREVIOUS>,
+					<0xbf	KEY_NEXT>,
+					<0xbc	KEY_PLAYPAUSE>,
+					<0xf8	KEY_VOLUMEDOWN>,
+					<0xea	KEY_VOLUMEUP>,
+					<0xf6	KEY_EQUAL>,
+					<0xe9	KEY_0>,
+					<0xf3	KEY_1>,
+					<0xe7	KEY_2>,
+					<0xa1	KEY_3>,
+					<0xf7	KEY_4>,
+					<0xe3	KEY_5>,
+					<0xa5	KEY_6>,
+					<0xbd	KEY_7>,
+					<0xad	KEY_8>,
+					<0xb5	KEY_9>;
+			};
+		};
+	};
+};

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-pwm-ir-remotectl.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-pwm-ir-remotectl.dts
@@ -9,7 +9,7 @@
 		title = "Enable IR receiver on PWM1";
 		compatible = "rockchip,rk3399";
 		category = "misc";
-		exclusive = "GPIO4_C6";
+		exclusive = "GPIO4_C6", "pwm1";
 		description = "Enable IR receiver on PWM1.";
 	};
 
@@ -38,9 +38,9 @@
 					<0xf8	KEY_VOLUMEDOWN>,
 					<0xea	KEY_VOLUMEUP>,
 					<0xf6	KEY_EQUAL>,
-					<0xe9	KEY_0>,
 					<0xe6	KEY_F1>,
 					<0xf2	KEY_F2>,
+					<0xe9	KEY_0>,
 					<0xf3	KEY_1>,
 					<0xe7	KEY_2>,
 					<0xa1	KEY_3>,

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-pwm-ir-remotectl.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-pwm-ir-remotectl.dts
@@ -39,6 +39,8 @@
 					<0xea	KEY_VOLUMEUP>,
 					<0xf6	KEY_EQUAL>,
 					<0xe9	KEY_0>,
+					<0xe6	KEY_F1>,
+					<0xf2	KEY_F2>,
 					<0xf3	KEY_1>,
 					<0xe7	KEY_2>,
 					<0xa1	KEY_3>,

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-pwm1-ir-rx.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-pwm1-ir-rx.dts
@@ -29,13 +29,13 @@
 			ir_key1 {
 				rockchip,usercode = <0xff00>;
 				rockchip,key_table =
-					<0xba KEY_CHANNELDOWN>,		<0xb9 KEY_CHANNEL>,		<0xb8 KEY_CHANNELUP>,
-					<0xbb KEY_PREVIOUS>, 		<0xbf KEY_NEXT>,		<0xbc KEY_PLAYPAUSE>,
-					<0xf8 KEY_VOLUMEDOWN>,		<0xea KEY_VOLUMEUP>,		<0xf6 KEY_EQUAL>,
-					<0xe9 KEY_0>,			<0xe6 KEY_F1>,			<0xf2 KEY_F2>,
-					<0xf3 KEY_1>,			<0xe7 KEY_2>, 			<0xa1 KEY_3>,
-					<0xf7 KEY_4>,			<0xe3 KEY_5>, 			<0xa5 KEY_6>,
-					<0xbd KEY_7>,			<0xad KEY_8>, 			<0xb5 KEY_9>;
+					<0xba KEY_CHANNELDOWN>,	<0xb9 KEY_CHANNEL>,	<0xb8 KEY_CHANNELUP>,
+					<0xbb KEY_PREVIOUS>,	<0xbf KEY_NEXT>,	<0xbc KEY_PLAYPAUSE>,
+					<0xf8 KEY_VOLUMEDOWN>,	<0xea KEY_VOLUMEUP>,	<0xf6 KEY_EQUAL>,
+					<0xe9 KEY_0>,		<0xe6 KEY_F1>,		<0xf2 KEY_F2>,
+					<0xf3 KEY_1>,		<0xe7 KEY_2>, 		<0xa1 KEY_3>,
+					<0xf7 KEY_4>,		<0xe3 KEY_5>, 		<0xa5 KEY_6>,
+					<0xbd KEY_7>,		<0xad KEY_8>, 		<0xb5 KEY_9>;
 			};
 		};
 	};

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-pwm1-ir-rx.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-pwm1-ir-rx.dts
@@ -29,13 +29,13 @@
 			ir_key1 {
 				rockchip,usercode = <0xff00>;
 				rockchip,key_table =
-					<0xba KEY_CHANNELDOWN>, <0xb9 KEY_CHANNEL>, <0xb8 KEY_CHANNELUP>,
-					<0xbb KEY_PREVIOUS>, <0xbf KEY_NEXT>, <0xbc KEY_PLAYPAUSE>,
-					<0xf8 KEY_VOLUMEDOWN>, <0xea KEY_VOLUMEUP>, <0xf6 KEY_EQUAL>,
-					<0xe9 KEY_0>, <0xe6 KEY_F1>, <0xf2 KEY_F2>,
-					<0xf3 KEY_1>, <0xe7 KEY_2>, <0xa1 KEY_3>,
-					<0xf7 KEY_4>, <0xe3 KEY_5>, <0xa5 KEY_6>,
-					<0xbd KEY_7>, <0xad KEY_8>, <0xb5 KEY_9>;
+					<0xba KEY_CHANNELDOWN>,		<0xb9 KEY_CHANNEL>,		<0xb8 KEY_CHANNELUP>,
+					<0xbb KEY_PREVIOUS>, 		<0xbf KEY_NEXT>,		<0xbc KEY_PLAYPAUSE>,
+					<0xf8 KEY_VOLUMEDOWN>,		<0xea KEY_VOLUMEUP>,		<0xf6 KEY_EQUAL>,
+					<0xe9 KEY_0>,			<0xe6 KEY_F1>,			<0xf2 KEY_F2>,
+					<0xf3 KEY_1>,			<0xe7 KEY_2>, 			<0xa1 KEY_3>,
+					<0xf7 KEY_4>,			<0xe3 KEY_5>, 			<0xa5 KEY_6>,
+					<0xbd KEY_7>,			<0xad KEY_8>, 			<0xb5 KEY_9>;
 			};
 		};
 	};

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-pwm1-ir-rx.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-pwm1-ir-rx.dts
@@ -5,7 +5,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
-    metadata {
+	metadata {
 		title = "Enable IR receiver on PWM1";
 		compatible = "rockchip,rk3399";
 		category = "misc";
@@ -29,27 +29,13 @@
 			ir_key1 {
 				rockchip,usercode = <0xff00>;
 				rockchip,key_table =
-					<0xba	KEY_CHANNELDOWN>,
-					<0xb9	KEY_CHANNEL>,
-					<0xb8	KEY_CHANNELUP>,
-					<0xbb	KEY_PREVIOUS>,
-					<0xbf	KEY_NEXT>,
-					<0xbc	KEY_PLAYPAUSE>,
-					<0xf8	KEY_VOLUMEDOWN>,
-					<0xea	KEY_VOLUMEUP>,
-					<0xf6	KEY_EQUAL>,
-					<0xe6	KEY_F1>,
-					<0xf2	KEY_F2>,
-					<0xe9	KEY_0>,
-					<0xf3	KEY_1>,
-					<0xe7	KEY_2>,
-					<0xa1	KEY_3>,
-					<0xf7	KEY_4>,
-					<0xe3	KEY_5>,
-					<0xa5	KEY_6>,
-					<0xbd	KEY_7>,
-					<0xad	KEY_8>,
-					<0xb5	KEY_9>;
+					<0xba KEY_CHANNELDOWN>, <0xb9 KEY_CHANNEL>, <0xb8 KEY_CHANNELUP>,
+					<0xbb KEY_PREVIOUS>, <0xbf KEY_NEXT>, <0xbc KEY_PLAYPAUSE>,
+					<0xf8 KEY_VOLUMEDOWN>, <0xea KEY_VOLUMEUP>, <0xf6 KEY_EQUAL>,
+					<0xe9 KEY_0>, <0xe6 KEY_F1>, <0xf2 KEY_F2>,
+					<0xf3 KEY_1>, <0xe7 KEY_2>, <0xa1 KEY_3>,
+					<0xf7 KEY_4>, <0xe3 KEY_5>, <0xa5 KEY_6>,
+					<0xbd KEY_7>, <0xad KEY_8>, <0xb5 KEY_9>;
 			};
 		};
 	};


### PR DESCRIPTION
遥控器是 car mp3, 和[这款](https://gist.github.com/danyboy666/f342c1cca26e88e0e637ee071698ac56)样式一样，但是目前还有两个按键没有适配(100+ 200+), 一是找不到定义，二是自己定义一个不生效