### PR TITLE
fix the description of rk3399-spi1-mcp2515-8mhz

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-spi1-mcp2515-8mhz.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-spi1-mcp2515-8mhz.dts
@@ -6,8 +6,8 @@
 		title = "Enable MCP2515 with 8MHz external clock on SPI1";
 		compatible = "radxa,rock-4c-plus";
 		category = "misc";
-		exclusive = "GPIO1_B0", "GPIO1_A7", "GPIO1_B1", "GPIO1_B2", "GPIO4_D6";
-		description = "Provide support for Microchip MCP2515 SPI CAN controller.\nAssumes 8MHz external clock.\nUses Pin 19 (GPIOI1_B2) for INT.";
+		exclusive = "GPIO1_B0", "GPIO1_A7", "GPIO1_B1", "GPIO1_B2", "GPIO4_D5";
+		description = "Provide support for Microchip MCP2515 SPI CAN controller.\nAssumes 8MHz external clock.\nUses Pin 22 (GPIO4_D5) for INT.";
 	};
 
 	fragment@0 {


### PR DESCRIPTION
rockchip,pins = <4 29 0 &pcfg_pull_none>;
中断脚当时写错了，bank 4 的第 29 个 pin 是 GPIO4_D5