### PR TITLE
rockchip: rk3399: Limit spi maximum rate

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-spi1-jedec-nor.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-spi1-jedec-nor.dts
@@ -22,7 +22,7 @@
 			spiflash@0 {
 				compatible = "jedec,spi-nor";
 				reg = <0>;
-				spi-max-frequency = <10000000>;
+				spi-max-frequency = <8000000>;
 				status = "okay";
 			};
 		};

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3399-spi2-jedec-nor.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3399-spi2-jedec-nor.dts
@@ -22,7 +22,7 @@
 			spiflash@0 {
 				compatible = "jedec,spi-nor";
 				reg = <0>;
-				spi-max-frequency = <10000000>;
+				spi-max-frequency = <8000000>;
 				status = "okay";
 			};
 		};


### PR DESCRIPTION
Excessive speed rates may result in written data
not matching the actual data.