### PR TITLE
disable spi2, cs0 is occupied by rk806

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rk3588-spi2-m1-cs0-spidev.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3588-spi2-m1-cs0-spidev.dts
@@ -4,7 +4,7 @@
 / {
 	metadata {
 		title = "Enable spidev on SPI2-M1 over CS0";
-		compatible = "radxa,cm5-io";
+		compatible = "unknown";
 		category = "misc";
 		exclusive = "GPIO4_A4", "GPIO4_A5", "GPIO4_A6", "GPIO4_A7";
 		description = "Enable spidev on SPI2-M1 over CS0.";


### PR DESCRIPTION
log: 
[    6.740823] spi_master spi2: spi_device register error /spi@feb20000/rk806single@0

开了这个 overlay 系统会起不来