### PR TITLE
Modify the overlay of rk3328-rock-pi-e.

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -18,7 +18,7 @@ endif
 dtb-$(CONFIG_CLK_RK3308) += \
 	rk3308-bs-opp-1008.dtbo \
 	rk3308-bs-opp-1296.dtbo \
-	rk3308-uart3.dtbo 
+	rk3308-uart3.dtbo
 
 dtb-$(CONFIG_CLK_RK3328) += \
 	rk3328-pwm2.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -15,7 +15,11 @@ endif
 dtb-$(CONFIG_CLK_RK3308) += \
 	rk3308-bs-opp-1008.dtbo \
 	rk3308-bs-opp-1296.dtbo \
-	rk3308-uart3.dtbo
+	rk3308-uart3.dtbo \
+	rk3328-pwm2.dtbo \
+	rk3328-uart1.dtbo \
+	rk3328-uart2-m0.dtbo \
+	rk3328-spi0-spidev.dtbo
 
 dtb-$(CONFIG_CLK_RK3399) += \
 	rk3399-dwc3-0-host.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -2,6 +2,9 @@
 ifeq ($(strip $(CONFIG_CPU_RK3308)), y)
 	CONFIG_CLK_RK3308 ?= y
 endif
+ifeq ($(strip $(CONFIG_CPU_RK3328)), y)
+	CONFIG_CLK_RK3328 ?= y
+endif
 ifeq ($(strip $(CONFIG_CPU_RK3399)), y)
 	CONFIG_CLK_RK3399 ?= y
 endif
@@ -15,7 +18,9 @@ endif
 dtb-$(CONFIG_CLK_RK3308) += \
 	rk3308-bs-opp-1008.dtbo \
 	rk3308-bs-opp-1296.dtbo \
-	rk3308-uart3.dtbo \
+	rk3308-uart3.dtbo 
+
+dtb-$(CONFIG_CLK_RK3328) += \
 	rk3328-pwm2.dtbo \
 	rk3328-uart1.dtbo \
 	rk3328-uart2-m0.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3328-pwm2.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3328-pwm2.dts
@@ -16,7 +16,7 @@
 		__overlay__ {
 			status = "okay";
 			pinctrl-names = "default";
-			pinctrl-0 = <&pwm0_pin>;
+			pinctrl-0 = <&pwm2_pin>;
 		};
 	};
 };

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3328-spi0-spidev.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3328-spi0-spidev.dts
@@ -21,7 +21,7 @@
 			#size-cells = <0>;
 
 			spidev@0 {
-				compatible = "armbian,spi-dev";
+				compatible = "rockchip,spidev", "armbian,spi-dev";
 				reg = <0>;
 				spi-max-frequency = <50000000>;
 			};

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3328-spi0-spidev.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3328-spi0-spidev.dts
@@ -21,7 +21,7 @@
 			#size-cells = <0>;
 
 			spidev@0 {
-				compatible = "rockchip,spidev";
+				compatible = "armbian,spi-dev";
 				reg = <0>;
 				spi-max-frequency = <50000000>;
 			};


### PR DESCRIPTION
1. The previous rk3328-pwm2.dts defines pwm0_pin incorrectly, change it to the correct pwm2_pin.
2. Changed the compatible attribute of rk3328-spi0-spidev.dts to "armbian,spi-dev" to match the spidev driver of the upstream kernel.
3. Added dtbo to Makefile to compile rk3328 overlay.