### PR TITLE
Modified the overlay of rk3308 i2c3-m0 ,pwm2, pwm3.

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rk3308-i2c3-m0.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3308-i2c3-m0.dts
@@ -1,6 +1,8 @@
 /dts-v1/;
 /plugin/;
 
+#include <dt-bindings/pinctrl/rockchip.h>
+
 / {
 	metadata {
 		title = "Enable I2C3-M0";
@@ -17,6 +19,16 @@
 			status = "okay";
 			pinctrl-names = "default";
 			pinctrl-0 = <&i2c3m0_xfer>;
+		};
+	};
+
+	fragment@1 {
+		target = <&i2c3m0_xfer>;
+
+		__overlay__ {
+			rockchip,pins =
+				<0 RK_PB7 2 &pcfg_pull_up_12ma>,
+				<0 RK_PC0 2 &pcfg_pull_up_12ma>;
 		};
 	};
 };

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3308-pwm2.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3308-pwm2.dts
@@ -1,6 +1,8 @@
 /dts-v1/;
 /plugin/;
 
+#include <dt-bindings/pinctrl/rockchip.h>
+
 / {
 	metadata {
 		title = "Enable PWM2";
@@ -15,8 +17,17 @@
 
 		__overlay__ {
 			status = "okay";
-			pinctrl-names = "active";
+			pinctrl-names = "default";
 			pinctrl-0 = <&pwm2_pin>;
+		};
+	};
+
+	fragment@1 {
+		target = <&pwm2_pin>;
+
+		__overlay__ {
+			rockchip,pins =
+				<0 RK_PB7 1 &pcfg_pull_up_12ma>;
 		};
 	};
 };

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3308-pwm3.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3308-pwm3.dts
@@ -1,6 +1,8 @@
 /dts-v1/;
 /plugin/;
 
+#include <dt-bindings/pinctrl/rockchip.h>
+
 / {
 	metadata {
 		title = "Enable PWM3";
@@ -15,8 +17,17 @@
 
 		__overlay__ {
 			status = "okay";
-			pinctrl-names = "active";
+			pinctrl-names = "default";
 			pinctrl-0 = <&pwm3_pin>;
+		};
+	};
+
+	fragment@1 {
+		target = <&pwm3_pin>;
+
+		__overlay__ {
+			rockchip,pins =
+				<0 RK_PC0 1 &pcfg_pull_up_12ma>;
 		};
 	};
 };


### PR DESCRIPTION
Reasons for changes to  i2c3-m0 : The level of the enable output is only 0.23V, pcfg_pull_up_12ma is added to raise the level to 3.3 V.


Reasons for changes to  pwm2 / pwm3 :  Changed the pinctrl-names from `acticve` to `default`, and also raised the output voltage to 3.3 V.