### PR TITLE
rk3328: Changed Makefile and changed uart2-m0 to uart2-m1.

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -48,7 +48,7 @@ dtb-$(CONFIG_CLK_RK3308) += \
 dtb-$(CONFIG_CLK_RK3328) += \
 	rk3328-pwm2.dtbo \
 	rk3328-uart1.dtbo \
-	rk3328-uart2-m0.dtbo \
+	rk3328-uart2-m1.dtbo \
 	rk3328-spi0-spidev.dtbo
 
 dtb-$(CONFIG_CLK_RK3399) += \

--- a/arch/arm64/boot/dts/rockchip/overlays/rk3328-uart2-m1.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3328-uart2-m1.dts
@@ -3,11 +3,11 @@
 
 / {
 	metadata {
-		title = "Enable UART2-M0";
-		compatible = "rockchip,rk3328";
+		title = "Enable UART2-M1";
+		compatible = "unknown";
 		category = "misc";
-		exclusive = "GPIO1_A0", "GPIO1_A1";
-		description = "Enable UART2-M0";
+		exclusive = "GPIO2_A0", "GPIO2_A1";
+		description = "Enable UART2-M1";
 	};
 
 	fragment@0 {


### PR DESCRIPTION
Fixed previous error, rk3328 uart2 uses uart2m1_xfer pin. The reason for the change from compatible to unknow is that uart2 is already turned on in rock-pi-e.dts.