### PR TITLE
Change title and description to Radxa Camera 8M 219

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3-io-radxa-camera-8m-cam1.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3-io-radxa-camera-8m-cam1.dts
@@ -6,11 +6,11 @@
 
 / {
 	metadata {
-		title = "Enable Radxa Camera 8M on CM3 IO v1.34+ CAM1";
+		title = "Enable Radxa Camera 8M 219 on CM3 IO v1.34+ CAM1";
 		compatible = "radxa,cm3-io";
 		category = "camera";
 		exclusive = "csi2_dphy1";
-		description = "Enable Radxa Camera 8M on CM3 IO v1.34+ CAM1.";
+		description = "Enable Radxa Camera 8M 219 on CM3 IO v1.34+ CAM1.";
 	};
 
 	fragment@0 {

--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3-io-radxa-camera-8m-cam2.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3-io-radxa-camera-8m-cam2.dts
@@ -6,11 +6,11 @@
 
 / {
 	metadata {
-		title = "Enable Radxa Camera 8M on CM3 IO v1.34+ CAM2";
+		title = "Enable Radxa Camera 8M 219 on CM3 IO v1.34+ CAM2";
 		compatible = "radxa,cm3-io";
 		category = "camera";
 		exclusive = "csi2_dphy2";
-		description = "Enable Radxa Camera 8M on CM3 IO v1.34+ CAM1.";
+		description = "Enable Radxa Camera 8M 219 on CM3 IO v1.34+ CAM1.";
 	};
 
 	fragment@0 {

--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3i-io-radxa-camera-8m-cam1.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3i-io-radxa-camera-8m-cam1.dts
@@ -6,11 +6,11 @@
 
 / {
 	metadata {
-		title = "Enable Radxa Camera 8M on CAM1";
+		title = "Enable Radxa Camera 8M 219 on CAM1";
 		compatible = "radxa,cm3i-io";
 		category = "camera";
 		exclusive = "csi2_dphy1";
-		description = "Enable Radxa Camera 8M on CAM1.";
+		description = "Enable Radxa Camera 8M 219 on CAM1.";
 	};
 
 	fragment@0 {

--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3i-io-radxa-camera-8m-cam2.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3i-io-radxa-camera-8m-cam2.dts
@@ -6,11 +6,11 @@
 
 / {
 	metadata {
-		title = "Enable Radxa Camera 8M on CAM2";
+		title = "Enable Radxa Camera 8M 219 on CAM2";
 		compatible = "radxa,cm3i-io";
 		category = "camera";
 		exclusive = "csi2_dphy2";
-		description = "Enable Radxa Camera 8M on CAM2.";
+		description = "Enable Radxa Camera 8M 219 on CAM2.";
 	};
 
 	fragment@0 {

--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3s-io-csi0-radxa-camera-8m.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3s-io-csi0-radxa-camera-8m.dts
@@ -6,11 +6,11 @@
 
 / {
 	metadata {
-		title = "Enable Radxa Camera 8M on CSI0";
+		title = "Enable Radxa Camera 8M 219 on CSI0";
 		compatible = "radxa,cm3s-io", "radxa,radxa-cm3-sodimm-io";
 		category = "camera";
 		exclusive = "csi2_dphy1";
-		description = "Enable Radxa Camera 8M on CSI0.";
+		description = "Enable Radxa Camera 8M 219 on CSI0.";
 	};
 
 	fragment@0 {

--- a/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3s-io-csi1-radxa-camera-8m.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/radxa-cm3s-io-csi1-radxa-camera-8m.dts
@@ -6,11 +6,11 @@
 
 / {
 	metadata {
-		title = "Enable Radxa Camera 8M on CSI1";
+		title = "Enable Radxa Camera 8M 219 on CSI1";
 		compatible = "radxa,cm3s-io", "radxa,radxa-cm3-sodimm-io";
 		category = "camera";
 		exclusive = "csi2_dphy2";
-		description = "Enable Radxa Camera 8M on CSI1.";
+		description = "Enable Radxa Camera 8M 219 on CSI1.";
 	};
 
 	fragment@0 {

--- a/arch/arm64/boot/dts/rockchip/overlays/rock-3ab-radxa-camera-8m.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rock-3ab-radxa-camera-8m.dts
@@ -7,11 +7,11 @@
 
 / {
 	metadata {
-		title = "Enable Radxa Camera 8M";
+		title = "Enable Radxa Camera 8M 219";
 		compatible = "radxa,rock-3a", "radxa,rock-3b";
 		category = "camera";
 		exclusive = "csi2_dphy0";
-		description = "Enable Radxa Camera 8M.";
+		description = "Enable Radxa Camera 8M 219.";
 	};
 
 	fragment@0 {

--- a/arch/arm64/boot/dts/rockchip/overlays/rock-3c-radxa-camera-8m.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rock-3c-radxa-camera-8m.dts
@@ -7,11 +7,11 @@
 
 / {
 	metadata {
-		title = "Enable Radxa Camera 8M";
+		title = "Enable Radxa Camera 8M 219";
 		compatible = "radxa,rock-3c";
 		category = "camera";
 		exclusive = "csi2_dphy0";
-		description = "Enable Radxa Camera 8M.";
+		description = "Enable Radxa Camera 8M 219.";
 	};
 
 	fragment@0 {

--- a/arch/arm64/boot/dts/rockchip/overlays/rock-4-radxa-camera-8m.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rock-4-radxa-camera-8m.dts
@@ -6,11 +6,11 @@
 
 / {
 	metadata {
-		title = "Enable Radxa Camera 8M";
+		title = "Enable Radxa Camera 8M 219";
 		compatible = "rockchip,rk3399";
 		category = "camera";
 		exclusive = "mipi_dphy_rx0";
-		description = "Enable Radxa Camera 8M.";
+		description = "Enable Radxa Camera 8M 219.";
 	};
 
 	fragment@0 {


### PR DESCRIPTION
Since the name of the camera was changed from Radxa Camera 8M to Radxa Camera 8M 219, the title and description in the overlay associated with it have to be changed.