### PR TITLE
rk3588: remove otg mode overlay

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/rk3588-dwc3-otg.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rk3588-dwc3-otg.dts
@@ -4,7 +4,7 @@
 / {
 	metadata {
 		title = "Set OTG port 0 to OTG mode";
-		compatible = "rockchip,rk3588";
+		compatible = "unknown";
 		category = "misc";
 		exclusive = "usbdrd_dwc3-dr_mode";
 		description = "Set OTG port 0 to OTG mode.\nUse this for automatic USB role switching.";


### PR DESCRIPTION
dr_mode is set to otg by kernel.