### PR TITLE
rockchip: add watch dog support

### DIFF
--- a/arch/arm64/boot/dts/amlogic/overlays/Makefile
+++ b/arch/arm64/boot/dts/amlogic/overlays/Makefile
@@ -39,6 +39,8 @@ dtb-$(CONFIG_ARCH_MESON) += \
 	radxa-zero2-enable-vddio_c.dtbo \
 	radxa-zero2-radxa-25w-poe.dtbo
 
+dtb-y += amlogic-g12-watchdog.dtbo
+
 dtbotxt-$(CONFIG_ARCH_MESON) += \
 	README.overlays
 

--- a/arch/arm64/boot/dts/amlogic/overlays/amlogic-g12-watchdog.dts
+++ b/arch/arm64/boot/dts/amlogic/overlays/amlogic-g12-watchdog.dts
@@ -1,0 +1,20 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable Watchdog";
+		compatible = "amlogic,g12a", "amlogic,g12b";
+		category = "misc";
+		exclusive = "wdt";
+		description = "Enable Watchdog.";
+	};
+
+	fragment@0 {
+		target = <&watchdog>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -426,6 +426,8 @@ dtb-$(CONFIG_CPU_RK3588) += \
 	rock-5b-plus-cam0-rpi-camera-v2.dtbo \
 	rock-5b-plus-cam1-rpi-camera-v2.dtbo
 
+dtb-y += rockchip-watchdog.dtbo
+
 dtbotxt-$(CONFIG_ARCH_ROCKCHIP) += \
 	README.overlays
 

--- a/arch/arm64/boot/dts/rockchip/overlays/rockchip-watchdog.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rockchip-watchdog.dts
@@ -1,0 +1,20 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable Watchdog";
+		compatible = "rockchip,rk3308", "rockchip,rk3328", "rockchip,rk3399", "rockchip,rk3566", "rockchip,rk3568", "rockchip,rk3588";
+		category = "misc";
+		exclusive = "wdt";
+		description = "Enable Watchdog.";
+	};
+
+	fragment@0 {
+		target = <&wdt>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};


### PR DESCRIPTION
Signed-off-by: Nascs Fang <nascs@radxa.com>

rk3399, 用的是 4C+ 做的测试， rk356x 用的是 CM3-IO， rk3588 用的是 5B