### PR TITLE
update overlay for rock5itx

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -398,6 +398,7 @@ dtb-$(CONFIG_CPU_RK3588) += \
 	radxa-cm5-rpi-cm4-io-raspi-7inch-ts-disp1.dtbo \
 	rock-5-itx-enable-sharp-lq133t1jw01-edp-lcd-disable-dp0.dtbo \
 	rock-5-itx-enable-sharp-lq133t1jw01-edp-lcd-disable-dp1.dtbo \
+	rock-5-itx-hdmi1-8k.dtbo \
 	rock-5-itx-okdo-5mp-camera-on-cam0.dtbo \
 	rock-5-itx-okdo-5mp-camera-on-cam1.dtbo \
 	rock-5-itx-radxa-camera-4k-on-cam0.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlays/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlays/Makefile
@@ -396,6 +396,7 @@ dtb-$(CONFIG_CPU_RK3588) += \
 	radxa-cm5-rpi-cm4-camera-v2-imx219-cam1.dtbo \
 	radxa-cm5-rpi-cm4-io-raspi-7inch-ts-disp0.dtbo \
 	radxa-cm5-rpi-cm4-io-raspi-7inch-ts-disp1.dtbo \
+	rock-5-itx-enable-sharp-lq133t1jw01-edp-lcd-disable-dp0.dtbo \
 	rock-5-itx-enable-sharp-lq133t1jw01-edp-lcd-disable-dp1.dtbo \
 	rock-5-itx-okdo-5mp-camera-on-cam0.dtbo \
 	rock-5-itx-okdo-5mp-camera-on-cam1.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlays/rock-5-itx-enable-sharp-lq133t1jw01-edp-lcd-disable-dp0.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rock-5-itx-enable-sharp-lq133t1jw01-edp-lcd-disable-dp0.dts
@@ -1,0 +1,239 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/rk3588-cru.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	metadata {
+		title = "Enable Sharp LQ133T1JW01 Display on eDP and Disable DP0";
+		compatible = "radxa,rock-5-itx";
+		category = "display";
+		exclusive = "dp0", "edp0", "vp2";
+		description = "Enable Sharp LQ133T1JW01 display on eDP.\nThis will disable DP0.";
+	};
+
+	fragment@0 {
+		target-path = "/";
+
+		__overlay__ {
+			backlight_edp0: backlight-edp0 {
+				status = "okay";
+				compatible = "pwm-backlight";
+				pwms = <&pwm8 0 25000 0>;
+				brightness-levels = <
+					0  20  20  21  21  22  22  23
+					23  24  24  25  25  26  26  27
+					27  28  28  29  29  30  30  31
+					31  32  32  33  33  34  34  35
+					35  36  36  37  37  38  38  39
+					40  41  42  43  44  45  46  47
+					48  49  50  51  52  53  54  55
+					56  57  58  59  60  61  62  63
+					64  65  66  67  68  69  70  71
+					72  73  74  75  76  77  78  79
+					80  81  82  83  84  85  86  87
+					88  89  90  91  92  93  94  95
+					96  97  98  99 100 101 102 103
+					104 105 106 107 108 109 110 111
+					112 113 114 115 116 117 118 119
+					120 121 122 123 124 125 126 127
+					128 129 130 131 132 133 134 135
+					136 137 138 139 140 141 142 143
+					144 145 146 147 148 149 150 151
+					152 153 154 155 156 157 158 159
+					160 161 162 163 164 165 166 167
+					168 169 170 171 172 173 174 175
+					176 177 178 179 180 181 182 183
+					184 185 186 187 188 189 190 191
+					192 193 194 195 196 197 198 199
+					200 201 202 203 204 205 206 207
+					208 209 210 211 212 213 214 215
+					216 217 218 219 220 221 222 223
+					224 225 226 227 228 229 230 231
+					232 233 234 235 236 237 238 239
+					240 241 242 243 244 245 246 247
+					248 249 250 251 252 253 254 255
+				>;
+				default-brightness-level = <200>;
+				enable-gpios = <&gpio3 RK_PA4 GPIO_ACTIVE_HIGH>;
+			};
+
+			vcc3v3_lcd_edp0: vcc3v3-lcd-edp0 {
+				status = "okay";
+				compatible = "regulator-fixed";
+				gpio = <&gpio3 RK_PA6 GPIO_ACTIVE_HIGH>;
+				enable-active-high;
+				regulator-name = "vcc3v3_lcd_edp0";
+				regulator-boot-on;
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				vin-supply = <&vcc3v3_sys>;
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			edp0_panel: edp0-panel {
+				status = "okay";
+				compatible = "simple-panel";
+				backlight = <&backlight_edp0>;
+				power-supply = <&vcc3v3_lcd_edp0>;
+				pinctrl-names = "default";
+				prepare-delay-ms = <100>;
+				enable-delay-ms = <100>;
+				bpc = <8>;
+				width-mm = <305>;
+				height-mm = <107>;
+				display-timings {
+					native-mode = <&timing0>;
+					timing0: timing0 {
+						clock-frequency = <237600000>;
+						hactive = <2560>;
+						vactive = <1440>;
+						hfront-porch = <80>;
+						hsync-len = <32>;
+						hback-porch = <48>;
+						vfront-porch = <31>;
+						vsync-len = <5>;
+						vback-porch = <3>;
+						hsync-active = <0>;
+						vsync-active = <0>;
+						de-active = <0>;
+						pixelclk-active = <0>;
+					};
+				};
+
+				ports {
+					panel_in_edp0: endpoint {
+							remote-endpoint = <&edp0_out_panel>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&pwm8>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "active";
+			pinctrl-0 = <&pwm8m0_pins>;
+
+		};
+	};
+
+	fragment@2 {
+		target = <&edp0>;
+
+		__overlay__ {
+			force-hpd;
+			disable-audio;
+			status = "okay";
+
+			ports {
+				port@1 {
+					reg = <1>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					edp0_out_panel: endpoint {
+						remote-endpoint = <&panel_in_edp0>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&hdptxphy0>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@4 {
+		target = <&edp0_in_vp2>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@5 {
+		target = <&edp0_in_vp0>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@6 {
+		target = <&edp0_in_vp1>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@7 {
+		target = <&route_edp0>;
+
+		__overlay__ {
+			status = "okay";
+			connect = <&vp0_out_edp0>;
+		};
+	};
+
+	fragment@8 {
+		target = <&dp0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@9 {
+		target = <&dp0_in_vp1>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@10 {
+		target = <&route_dp0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@11 {
+		target = <&dp0_sound>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@12 {
+		target = <&hdptxphy_hdmi_clk0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@13 {
+		target = <&hdptxphy_hdmi0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/rockchip/overlays/rock-5-itx-enable-sharp-lq133t1jw01-edp-lcd-disable-dp1.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rock-5-itx-enable-sharp-lq133t1jw01-edp-lcd-disable-dp1.dts
@@ -1,14 +1,15 @@
 /dts-v1/;
 /plugin/;
 
+#include <dt-bindings/clock/rk3588-cru.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pinctrl/rockchip.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
 / {
 	metadata {
-		title = "Enable Sharp LQ133T1JW01 Display on eDP";
-		compatible = "radxa,rock-5-itx";
+		title = "Enable Sharp LQ133T1JW01 Display on eDP and Disable DP1";
+		compatible = "unknown";
 		category = "display";
 		exclusive = "dp1", "edp0", "vp2";
 		description = "Enable Sharp LQ133T1JW01 display on eDP.\nThis will disable DP1.";
@@ -89,7 +90,7 @@
 				display-timings {
 					native-mode = <&timing0>;
 					timing0: timing0 {
-						clock-frequency = <241500000>;
+						clock-frequency = <237600000>;
 						hactive = <2560>;
 						vactive = <1440>;
 						hfront-porch = <80>;
@@ -217,6 +218,59 @@
 
 		__overlay__ {
 			status = "disabled";
+		};
+	};
+
+	fragment@12 {
+		target = <&display_subsystem>;
+
+		__overlay__ {
+			status = "okay";
+			/delete-property/ clocks;
+			/delete-property/ clock-names;
+		};
+	};
+
+	fragment@13 {
+		target = <&hdptxphy_hdmi_clk0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@14 {
+		target = <&hdptxphy_hdmi0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@15 {
+		target = <&vp0>;
+
+		__overlay__ {
+			assigned-clocks = <&cru DCLK_VOP0_SRC>;
+			assigned-clock-parents = <&cru PLL_V0PLL>;
+		};
+	};
+
+	fragment@16 {
+		target = <&vp1>;
+
+		__overlay__ {
+			assigned-clocks = <&cru DCLK_VOP1>;
+			assigned-clock-parents = <&hdptxphy_hdmi_clk1>;
+		};
+	};
+
+	fragment@17 {
+		target = <&vp2>;
+
+		__overlay__ {
+			assigned-clocks = <&cru DCLK_VOP2_SRC>;
+			assigned-clock-parents = <&cru PLL_GPLL>;
 		};
 	};
 };

--- a/arch/arm64/boot/dts/rockchip/overlays/rock-5-itx-hdmi1-8k.dts
+++ b/arch/arm64/boot/dts/rockchip/overlays/rock-5-itx-hdmi1-8k.dts
@@ -1,0 +1,72 @@
+/dts-v1/;
+/plugin/;
+#include <dt-bindings/clock/rk3588-cru.h>
+
+/ {
+	metadata {
+		title = "Enable 8K output on HDMI1";
+		compatible = "radxa,rock-5-itx";
+		category = "display";
+		exclusive = "dp0", "vp0", "hdmi1";
+		description = "Enable 8K output on HDMI1.\nThis will disable DP0.";
+	};
+
+	fragment@0 {
+		target = <&route_hdmi1>;
+
+		__overlay__ {
+			connect = <&vp1_out_hdmi1>;
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&hdmi1_in_vp0>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&hdmi1_in_vp1>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@3 {
+		target = <&route_dp0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@4 {
+		target = <&dp0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+
+	fragment@5 {
+		target = <&dp0_in_vp0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@6 {
+		target = <&vop>;
+
+		__overlay__ {
+			assigned-clocks = <&cru ACLK_VOP>;
+			assigned-clock-rates = <800000000>;
+		};
+	};
+};


### PR DESCRIPTION
1.close rock-5-itx-enable-sharp-lq133t1jw01-edp-lcd-disable-dp1 overlay
  The hdmiphyclk0 used by dp0 on the software is in conflict with edp0, so disable the dual-display function of edp0 and dp0.

2.add rock-5-itx-enable-sharp-lq133t1jw01-edp-lcd-disable-dp0 overlay